### PR TITLE
Removed H2 dependency which is used only for testing

### DIFF
--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -82,12 +82,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <scope>test</scope>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.1.214</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The H2 dependency has been flagged by dependabot as being insecure. Removing this dependency which is used to run tests and can be added as needed during testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
