### PR TITLE
Update postgres-schema.graphql

### DIFF
--- a/samples/postgres-schema.graphql
+++ b/samples/postgres-schema.graphql
@@ -27,6 +27,7 @@ type Graphqlsample_MyOrderItem implements Node {
 }
 
 type Graphqlsample_MyOrderItem_Connection {
+  pageInfo: PageInfo!
   edges: [Graphqlsample_MyOrderItem_Edge]
 }
 
@@ -74,7 +75,7 @@ type Mutation {
 }
 
 type Query {
-  graphqlsample_MyOrder(limit: Int, offset: Int, orderBy: [Graphqlsample_MyOrder_OrderByInput], where: Graphqlsample_MyOrder_FilterInput): Graphqlsample_MyOrder_Connection
+  graphqlsample_MyOrder(first: Int, limit: Int, offset: Int, orderBy: [Graphqlsample_MyOrder_OrderByInput], where: Graphqlsample_MyOrder_FilterInput): Graphqlsample_MyOrder_Connection
   graphqlsample_MyOrderItem(limit: Int, offset: Int, orderBy: [Graphqlsample_MyOrderItem_OrderByInput], where: Graphqlsample_MyOrderItem_FilterInput): Graphqlsample_MyOrderItem_Connection
   graphqlsample_MyProduct(limit: Int, offset: Int, orderBy: [Graphqlsample_MyProduct_OrderByInput], where: Graphqlsample_MyProduct_FilterInput): Graphqlsample_MyProduct_Connection
   node(id: ID!): Node
@@ -315,4 +316,11 @@ input StringOperator {
   lt: String
   ne: String
   nin: [String]
+}
+
+type PageInfo {
+	hasNextPage: Boolean!
+	hasPreviousPage: Boolean!
+	endCursor: String
+	startCursor: String
 }


### PR DESCRIPTION
Fix for an issue while surfacing data on Salesforce UI. The schema is missing pagination details as a result SF-UI throws the following error - EXTERNAL_OBJECT_EXCEPTION: Error calling service. Message: Validation error of type UnknownArgument: Unknown field argument first @ 'graphqlsample_MyOrder'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
